### PR TITLE
开源协议的格式问题

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -68,27 +68,6 @@
 
 条款结束
 
-如何将木兰公共许可证，第2版，应用到您的软件
-
-如果您希望将木兰公共许可证，第2版，应用到您的软件，为了方便接收者查阅，建议您完成如下三步：
-
-1， 请您补充如下声明中的空白，包括软件名、软件的首次发表年份以及您作为版权人的名字；
-
-2， 请您在软件包的一级目录下创建以“LICENSE”为名的文件，将整个许可证文本放入该文件中；
-
-3， 请将如下声明文本放入每个源文件的头部注释中。
-
-Copyright (c) 2025 Workchain Group
-Workchain Client is licensed under Mulan PubL v2.
-You can use this software according to the terms and conditions of the Mulan PubL v2.
-You may obtain a copy of Mulan PubL v2 at:
-         http://license.coscl.org.cn/MulanPubL-2.0
-THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
-EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
-MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
-See the Mulan PubL v2 for more details.
-
-
 Mulan Public License，Version 2
 
 Mulan Public License，Version 2 (Mulan PubL v2)
@@ -162,23 +141,3 @@ CONTRIBUTION ARE PROVIDED WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPL
 THIS LICENSE IS WRITTEN IN BOTH CHINESE AND ENGLISH, AND THE CHINESE VERSION AND ENGLISH VERSION SHALL HAVE THE SAME LEGAL EFFECT. IN THE CASE OF DIVERGENCE BETWEEN THE CHINESE AND ENGLISH VERSIONS, THE CHINESE VERSION SHALL PREVAIL.
 
 END OF THE TERMS AND CONDITIONS
-
-How to apply the Mulan Public License，Version 2 (Mulan PubL v2), to your software
-
-To apply the Mulan Public License，Version 2 to your work, for easy identification by recipients, you are suggested to complete following three steps:
-
-Fill in the blanks in following statement, including insert your software name, the year of the first publication of your software, and your name identified as the copyright owner;
-
-Create a file named “LICENSE” which contains the whole context of this License in the first directory of your software package;
-
-Attach the statement to the appropriate annotated syntax at the beginning of each source file.
-
-Copyright (c) 2025 Workchain Group
-Workchain Client is licensed under Mulan PubL v2.
-You can use this software according to the terms and conditions of the Mulan PubL v2.
-You may obtain a copy of Mulan PubL v2 at:
-         http://license.coscl.org.cn/MulanPubL-2.0
-THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
-EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
-MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
-See the Mulan PubL v2 for more details.

--- a/LICENSE
+++ b/LICENSE
@@ -84,7 +84,7 @@ Contributor means the Individual or Legal Entity who licenses its copyrightable 
 
 Legal Entity means the entity making a Contribution and all its Affiliates.
 
-Affiliates mmeans entities that control, are controlled by, or are under common control with the acting entity under this License, ‘control’ means direct or indirect ownership of at least fifty percent (50%) of the voting power, capital or other securities of controlled or commonly controlled entity.
+Affiliates means entities that control, are controlled by, or are under common control with the acting entity under this License, ‘control’ means direct or indirect ownership of at least fifty percent (50%) of the voting power, capital or other securities of controlled or commonly controlled entity.
 
 Derivative Work means works created based on Contribution, specifically including works formed by modifying, rewriting, translating, annotating, combining or linking to all or part of Contribution (including dynamic linking or static linking). Works which only communicate with Contribution through inter-process communication or system call, are independent works, rather than Derivative Work.
 


### PR DESCRIPTION
1. “条款结束”后面的那段使用说明不是协议正文，故移除。本库已按照此说明添加注释。
2. 修复英文拼写错误：注意，这个拼写错误是在木兰公共许可证第二版原文中也有的(苔)：https://license.coscl.org.cn/MulanPubL-2.0#:~:text=Affiliates-,mmeans,-entities%20that%20control
(截止2025年5月2日15:00仍存在)